### PR TITLE
Fix escaping in .scalafmt.conf

### DIFF
--- a/src/main/g8/.scalafmt.conf
+++ b/src/main/g8/.scalafmt.conf
@@ -5,8 +5,8 @@ version = "2.1.1"
 #
 project {
   includeFilters = [
-    ".*.\\.scala\$"
-    ".*\\..sbt\$"
+    ".*.\\\\.scala\$"
+    ".*\\\\..sbt\$"
   ]
 }
 

--- a/src/main/g8/.scalafmt.conf
+++ b/src/main/g8/.scalafmt.conf
@@ -5,8 +5,8 @@ version = "2.1.1"
 #
 project {
   includeFilters = [
-    ".*.\\\\.scala\$"
-    ".*\\\\..sbt\$"
+    ".*\\\\.scala\$"
+    ".*\\\\.sbt\$"
   ]
 }
 


### PR DESCRIPTION
It looks like `\.` in the template should be double-escaped, as giter8 generated incorrect strings in the result:
```scala
project {
  includeFilters = [
    ".*.\.scala$"
    ".*\..sbt$"
  ]
}
```