### PR TITLE
Add node_modules/ to .gitignore for Scala.js jsdom

### DIFF
--- a/src/main/g8/.gitignore
+++ b/src/main/g8/.gitignore
@@ -17,3 +17,4 @@ project/metals.sbt
 .metals
 .bloop
 site/Gemfile.lock
+node_modules/


### PR DESCRIPTION
Resolves https://github.com/alexandru/typelevel-library.g8/issues/69