### PR TITLE
Add sbt-task 'site/run' to run microsite locally

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -289,6 +289,18 @@ lazy val site = project.in(file("site"))
       micrositeConfigYaml := microsites.ConfigYml(
         yamlCustomProperties = Map("exclude" -> List.empty[String])
       ),
+
+      run in Compile := {
+        import scala.sys.process._
+
+        val s: TaskStreams = streams.value
+        val shell: Seq[String] = if (sys.props("os.name").contains("Windows")) Seq("cmd", "/c") else Seq("bash", "-c")
+
+        val jekyllServe: String = s"jekyll serve --open-url --baseurl \${(micrositeBaseUrl in Compile).value}"
+
+        s.log.info("Running Jekyll...")
+        Process(shell :+ jekyllServe, (micrositeExtraMdFilesOutput in Compile).value) !
+      },
     )
   }
 


### PR DESCRIPTION
```sh
❯ sbt site/run
[info] welcome to sbt 1.3.13 (AdoptOpenJDK Java 11.0.7)
[info] loading settings for project global-plugins from plugins.sbt,gpg.sbt,build.sbt ...
[info] loading global plugins from /Users/eric/.sbt/1.0/plugins
[info] loading settings for project foo-build from plugins.sbt,metals.sbt ...
[info] loading project definition from /Users/eric/Work/foo/project
[info] loading settings for project root from build.sbt ...
[info] set current project to root (in build file:/Users/eric/Work/foo/)
[info] Running Jekyll...
Configuration file: /Users/eric/Work/foo/site/target/scala-2.13/resource_managed/main/jekyll/_config.yml
            Source: /Users/eric/Work/foo/site/target/scala-2.13/resource_managed/main/jekyll
       Destination: /Users/eric/Work/foo/site/target/scala-2.13/resource_managed/main/jekyll/_site
 Incremental build: disabled. Enable with --incremental
      Generating...
                    done in 0.179 seconds.
 Auto-regeneration: enabled for '/Users/eric/Work/foo/site/target/scala-2.13/resource_managed/main/jekyll'
    Server address: http://127.0.0.1:4000/foo/
  Server running... press ctrl-c to stop.
^C
[warn] Canceling execution...
[error] Total time: 38 s, completed Jul 20, 2020, 2:13:35 PM
    ~/Work/foo 

```