### PR TITLE
fix better-monadic-for link

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -60,7 +60,7 @@ val ScalaCheckVersion = "1.14.3"
 val KindProjectorVersion = "0.11.0"
 
 /** Compiler plugin for fixing "for comprehensions" to do desugaring w/o `withFilter`:
-  * [[https://github.com/typelevel/kind-projector]]
+  * [[https://github.com/oleg-py/better-monadic-for]]
   */
 val BetterMonadicForVersion = "0.3.1"
 


### PR DESCRIPTION
thanks for creating this! 

I was reading through the `build.sbt` file and noticed the link in the comments for [better-monadic-for](https://github.com/oleg-py/better-monadic-for) was pointing to the wrong link